### PR TITLE
Removed resetSkeleton on popover dismiss

### DIFF
--- a/components/calendar/form/CreateEvent.vue
+++ b/components/calendar/form/CreateEvent.vue
@@ -32,14 +32,6 @@ function openEventCreatePopover() {
   }
 }
 
-// Watch the popover state
-// And reset the skeleton if it has been dismissed
-watch(popoverOpen, (hasOpened, _o) => {
-  if (!hasOpened) {
-    resetSkeleton()
-  }
-})
-
 async function handleSubmit() {
   try {
     await submitSkeleton()


### PR DESCRIPTION
As the skeleton is already reset when it opens, it's redundant to reset it while it's not being displayed