### PR TITLE
Removed overkill pattern

### DIFF
--- a/components/calendar/form/UpdateEvent.vue
+++ b/components/calendar/form/UpdateEvent.vue
@@ -105,8 +105,8 @@ function handleCancel() {
                   name="new-event-title"
                   required
                   :placeholder="$t('entity.calendar.event.title')"
+                  :minlength="3"
                   :maxlength="120"
-                  pattern="([A-Za-zÀ-ÖØ-öø-ÿ0-9\s\&\-\~]+){3,120}"
                   class="w-full -my-1 py-1 -mx-1 px-1 text-lg border-b-[1px] bg-transparent focus-visible:outline-none focus-visible:border-blue-600 invalid:border-red-500"
                 >
                 <div class="mt-2 mb-1 text-xs opacity-50">
@@ -185,8 +185,8 @@ function handleCancel() {
                   type="text"
                   name="new-event-location"
                   :placeholder="$t('entity.calendar.event.addLocation')"
+                  :minlength="3"
                   :maxlength="160"
-                  pattern="([A-Za-zÀ-ÖØ-öø-ÿ0-9\s\&\-\~]+){3,160}"
                   class="w-full -my-1 py-2 px-2 text-sm border-b-[1px] bg-transparent focus-visible:outline-none focus-visible:border-blue-600 invalid:border-red-500"
                 >
 

--- a/i18n.config.ts
+++ b/i18n.config.ts
@@ -137,9 +137,9 @@ export default defineI18nConfig(() => ({
             prevPage: "Previous page with events",
             nextPage: "Next page with events",
             patterns: {
-              title: "Between 3 and 120 caracters, without special symbols, except & - ~ ()",
+              title: "Between 3 and 120 caracters.",
               description: "1200 caracters max.",
-              location: "Between 3 and 160 caracters, without special symbols, except & - ~ ()",
+              location: "Between 3 and 160 caracters.",
             },
             editDialog: {
               title: "Edit event",
@@ -356,9 +356,9 @@ export default defineI18nConfig(() => ({
             prevPage: "Précédente page à évènements",
             nextPage: "Prochaine page à évènements",
             patterns: {
-              title: "Entre 3 et 120 charactères, sans symboles spéciaux, sauf & - ~ ()",
+              title: "Entre 3 et 120 charactères.",
               description: "Maximum 1200 charactères.",
-              location: "Entre 3 et 160 charactères, sans symboles spéciaux, sauf & - ~ ()",
+              location: "Entre 3 et 160 charactères.",
             },
             editDialog: {
               title: "Modifier l'évènement",


### PR DESCRIPTION
This fixes the stack being trashed up for Firefox
Still curious on why that happened for a single Regex (maybe it was poorly optimized but it's like, very basic).

Idk Regexes are weird man